### PR TITLE
fix: ignore stale status positions beyond current dataset

### DIFF
--- a/src/component/List.svelte
+++ b/src/component/List.svelte
@@ -63,7 +63,7 @@
 	}
 
 	function fill_status(_status) {
-		return _status.padEnd(max_index + 1, '0').split('');
+		return _status.slice(0, max_index + 1).padEnd(max_index + 1, '0').split('');
 	}
 
 </script>


### PR DESCRIPTION
## Summary

This fixes incorrect header counters when a shared `?status=` string is longer than the current dataset.

The app stores checklist state by `index` position. `List.svelte` was padding short status strings to `max_index + 1`, but it was not truncating long ones. That meant stale extra positions from older or longer shared URLs were still counted in the header totals.

This change normalizes the loaded status string to the current dataset length before rendering or counting.

## What changed

In `src/component/List.svelte`:

- truncate `status` to `max_index + 1`
- then pad with `0` if needed

Before:
```js
return _status.padEnd(max_index + 1, '0').split('');
```

closes #55 