### PR TITLE
feature: add Released counter to header

### DIFF
--- a/src/component/Head.svelte
+++ b/src/component/Head.svelte
@@ -60,20 +60,6 @@
 	</div>
 
 	<div class="dashboard flex gap:min(2vw,1em) justify-content:center align-items:center user-select:none font-size:smaller">
-		<div
-			class="summary-card position:relative width:70 aspect-ratio:1 height:70 place-content:center place-items:center text-align:center"
-			title="Total"
-		>
-			<div class="number font-size:1.2rem">
-				{counts.total.summary}
-			</div>
-			<div class="white-space:nowrap overflow:hidden text-overflow:ellipsis width:100% padding:0|2 margin-top:.25em font-size:smaller opacity:0.5">
-				Total
-			</div>
-		</div>
-
-		/
-
 		{#each status_visibility as st, index}
 			{#if index}
 				/
@@ -100,6 +86,21 @@
 				<!-- </label> -->
 			</label>
 		{/each}
+
+		/
+
+		<div
+			class="pm status-0 summary-card position:relative width:70 aspect-ratio:1 height:70 place-content:center place-items:center text-align:center"
+			title="Released"
+		>
+			<input type="checkbox" class="sr-only-u" checked disabled>
+			<div class="number font-size:1.2rem">
+				{counts.total.summary}
+			</div>
+			<div class="white-space:nowrap overflow:hidden text-overflow:ellipsis width:100% padding:0|2 margin-top:.25em font-size:smaller opacity:0.5">
+				Released
+			</div>
+		</div>
 	</div>
 </header>
 


### PR DESCRIPTION
Closes #53

## Summary

This adds a `Released` counter to the header.

The new tile displays the total number of released shiny entries currently represented in the checklist.

## What changed

In `src/component/Head.svelte`:

- render a new `Released` summary tile in the header
- place it after the existing status counters
- use the total of all four status buckets:
  - Unregistered
  - Registered
  - Owned
  - Extra

Formula:

```text
Released = 0 + 1 + 2 + 3
