### PR TITLE
fix: export csv statuses by pokemon index

### DIFF
--- a/src/component/Export.svelte
+++ b/src/component/Export.svelte
@@ -15,7 +15,7 @@
 				if (prop === 'name') {
 					return pm[prop][_locale] || '';
 				} else if (prop === 'status') {
-					return _status[index] || 0;
+					return _status[pm.index] || 0;
 				}
 				return pm[prop] || '';
 			}).join(',');


### PR DESCRIPTION
Closes #52

## Summary

This fixes incorrect `status` values in CSV export for entries whose exported row position does not match their persisted checklist index.

The export code was reading status by array position instead of by the Pokémon's stored `index`.

## What changed

In `src/component/Export.svelte`:

Before:
```js
return _status[index] || 0;
