### PR TITLE
fix: increase header counter tile size

### DIFF
--- a/src/component/Head.svelte
+++ b/src/component/Head.svelte
@@ -65,7 +65,7 @@
 				/
 			{/if}
 
-			<label class="pm status-{index} position:relative width:70 aspect-ratio:1 height:70 place-content:center place-items:center text-align:center cursor:pointer"
+			<label class="pm status-{index} position:relative width:88 aspect-ratio:1 height:88 place-content:center place-items:center text-align:center cursor:pointer"
 				title={$_(`status.${status_labels[index]}`)}
 			>
 				<!-- <label class="label-has-checkbox cursor:pointer"> -->


### PR DESCRIPTION
Closes #6

## Summary

This increases the size of the header counter tiles so the longer status labels fit more reliably.

The current labels:

- Unregistered
- Registered
- Owned
- Extra

are more meaningful than the older names, but `Unregistered` in particular gets truncated in the current fixed tile size.

## What changed

In `src/component/Head.svelte`:

- increase the header counter tiles from `70x70` to `88x88`
- keep `aspect-ratio: 1` so the tiles remain square

## Why

The current header tiles are too small for the renamed labels, especially `Unregistered`.

This change keeps the clearer wording while making the UI readable without introducing abbreviations or changing status semantics.

## Notes

This is intentionally small:
- no label changes
- no behavior changes
- no persistence changes

It only adjusts the visual size of the header status tiles.
