### PR TITLE
fix: preserve zero values in csv export

### DIFF
--- a/src/component/Export.svelte
+++ b/src/component/Export.svelte
@@ -17,7 +17,7 @@
 				} else if (prop === 'status') {
 					return _status[index] || 0;
 				}
-				return pm[prop] || '';
+				return pm[prop] ?? '';
 			}).join(',');
 		});
 		csv.unshift(titles);


### PR DESCRIPTION
Closes #51

## Summary

This fixes CSV export dropping numeric `0` values, including the first row's `index`.

The export code was using `|| ''` for non-status fields, which turns `0` into an empty string.

## What changed

In `src/component/Export.svelte`:

Before:
```js
return pm[prop] || '';
