### PR TITLE
fix: count released rows from actual pokemon data

### DIFF
--- a/src/component/List.svelte
+++ b/src/component/List.svelte
@@ -23,8 +23,10 @@
 	let status_string = $derived(status_map.join(''));
 
 	let status_counter = $derived.by(() => {
-		return status_map.reduce((all, s) => {
-			all[+s] = (all[+s] || 0) + 1;
+		// Dataset indices are sparse, so count only actual released rows.
+		return pms.reduce((all, pm) => {
+			let s = Number(status_map[pm.index] || 0);
+			all[s] = (all[s] || 0) + 1;
 			return all;
 		}, [0, 0, 0, 0]);
 	});


### PR DESCRIPTION
I'm still trying to fix the count headers--they're still not correct. I have found another bug:

## Summary

- fix the `Released` header total so it counts actual released Pokemon rows
- stop counting sparse index gaps as released entries
- keep the existing shared-url/status trimming behavior unchanged

## Root cause

The header total was derived from `status_map`, which is padded to `max_index + 1`.

That works only if the dataset indices are contiguous. In the live dataset they are sparse, so missing indices were being counted as real released entries, which inflated the website total.

## Fix

Compute `status_counter` from `pms` and look up each row's status by `pm.index`, instead of reducing over the padded `status_map`.
