### PR TITLE
feat: add tag hide mode

### DIFF
--- a/src/component/Tag.svelte
+++ b/src/component/Tag.svelte
@@ -1,7 +1,7 @@
 <script>
 	import { pm_data, } from '@lib/pm.svelte.js';
 	import { _, } from 'svelte-i18n';
-	import { ordered_style, get_item, set_item, } from '@lib/u.js';
+	import { ordered_style, flat_group_style, get_item, set_item, } from '@lib/u.js';
 	import { config, } from '@/stores.js';
 
 	let { tags, } = pm_data;
@@ -9,6 +9,7 @@
 	let cached_tags = get_item('checked_tags') || [];
 
 	let is_cap = $state(get_item('filter_is_cap') || false);
+	let is_exclude = $state(get_item('filter_is_exclude') || false);
 
 	let tags_cloud = $state(
 		Object.keys(tags).sort().map(tag => {
@@ -24,6 +25,17 @@
 		set_item('filter_is_cap', is_cap);
 	})
 
+	$effect(() => {
+		set_item('filter_is_exclude', is_exclude);
+	})
+
+	function get_selectors(tags = []) {
+		if (is_cap) {
+			return '.pm-list .pm' + tags.map(tag => `.tag-${tag}`).join('');
+		}
+		return tags.map(tag => `.pm-list .pm.tag-${tag}`).join(',');
+	}
+
 	let style = $derived.by(() => {
 		let _tags = tags_cloud.map(tag => tag.checked && tag.label).filter(Boolean);
 		set_item('checked_tags', _tags);
@@ -32,17 +44,16 @@
 			return '';
 		}
 
-		let selectors = '';
-		if (is_cap) {
-			selectors = '.pm-list .pm' + _tags.map(tag => `.tag-${tag}`).join('');
-		} else {
-			selectors = _tags.map(tag => `.pm-list .pm.tag-${tag}`).join(',');
+		let selectors = get_selectors(_tags);
+		if (is_exclude) {
+			return flat_group_style + selectors + `{ display:none !important; }`;
 		}
 		return ordered_style + selectors + `{ display:flex; }`;
 	});
 
 	function reset_tags() {
 		is_cap = false;
+		is_exclude = false;
 		tags_cloud.forEach(tag => {
 			tag.checked = false;
 		})
@@ -56,12 +67,22 @@
 	<summary class="text-align:center hide-for-print opacity:0 transition:opacity|.3s"
 		accesskey="t">
 		🔖 {$_('tag')}
-	<label class="display:inline-flex width:fit-content margin:.5em|auto">
-		<input class="switcher" type="checkbox" data-inactive="∪" data-active="∩"
-			title={is_cap ? $_('tag.intersection_selected') : $_('tag.union_selected')}
-			bind:checked={is_cap}
-		/>
-	</label>
+	<span class="display:inline-flex gap:.25em margin:.5em|auto">
+		<label class="display:inline-flex width:fit-content">
+			<input class="switcher" type="checkbox" data-inactive="∪" data-active="∩"
+				title={is_cap ? $_('tag.intersection_selected') : $_('tag.union_selected')}
+				aria-label={is_cap ? $_('tag.intersection_selected') : $_('tag.union_selected')}
+				bind:checked={is_cap}
+			/>
+		</label>
+		<label class="display:inline-flex width:fit-content">
+			<input class="switcher" type="checkbox" data-inactive="show" data-active="hide"
+				title={is_exclude ? $_('tag.hide_selected') : $_('tag.show_selected')}
+				aria-label={is_exclude ? $_('tag.hide_selected') : $_('tag.show_selected')}
+				bind:checked={is_exclude}
+			/>
+		</label>
+	</span>
 	</summary>
 
 
@@ -112,6 +133,7 @@
 		font-family: inherit;
 		font-size: smaller;
 		cursor: pointer;
+		line-height: 1.2;
 
 		&::after,
 		&::before {

--- a/src/component/Tag.svelte
+++ b/src/component/Tag.svelte
@@ -6,16 +6,17 @@
 
 	let { tags, } = pm_data;
 
-	let cached_tags = get_item('checked_tags') || [];
+	let all_tags = Object.keys(tags).sort();
+	let cached_tags = get_cached_tags(all_tags);
 
 	let is_cap = $state(get_item('filter_is_cap') || false);
-	let is_exclude = $state(get_item('filter_is_exclude') || false);
 
 	let tags_cloud = $state(
-		Object.keys(tags).sort().map(tag => {
+		all_tags.map(tag => {
 			return {
 				label: tag,
-				checked: cached_tags.includes(tag),
+				checked: Object.prototype.hasOwnProperty.call(cached_tags, tag),
+				inverted: cached_tags[tag] || false,
 				count: tags[tag].length,
 			};
 		})
@@ -25,9 +26,62 @@
 		set_item('filter_is_cap', is_cap);
 	})
 
-	$effect(() => {
-		set_item('filter_is_exclude', is_exclude);
-	})
+	function invert_tag_label(label = '') {
+		return label.startsWith('-') ? label.slice(1) : `-${label}`;
+	}
+
+	function get_cached_tags(tag_labels = []) {
+		let cached_tags = get_item('checked_tags') || [];
+		if (Array.isArray(cached_tags)) {
+			let lookup = {};
+			let remaining_tags = new Set(cached_tags);
+
+			tag_labels.forEach(tag => {
+				if (remaining_tags.delete(tag)) {
+					lookup[tag] = false;
+				}
+			});
+
+			tag_labels.forEach(tag => {
+				if (remaining_tags.delete(invert_tag_label(tag))) {
+					lookup[tag] = true;
+				}
+			});
+
+			return lookup;
+		}
+
+		return Object.entries(cached_tags).reduce((all, [label, value]) => {
+			if (value === 'include') {
+				all[label] = false;
+			} else if (value === 'exclude') {
+				all[label] = true;
+			} else if (typeof value === 'boolean') {
+				all[label] = value;
+			} else if (value) {
+				all[label] = false;
+			}
+			return all;
+		}, {});
+	}
+
+	function invert_tags() {
+		tags_cloud.forEach(tag => {
+			if (tag.checked) {
+				tag.inverted = !tag.inverted;
+			}
+		})
+	}
+
+	function get_tag_display_label(tag) {
+		return tag.inverted ? invert_tag_label(tag.label) : tag.label;
+	}
+
+	function sync_tag(tag) {
+		if (!tag.checked) {
+			tag.inverted = false;
+		}
+	}
 
 	function get_selectors(tags = []) {
 		if (is_cap) {
@@ -37,25 +91,36 @@
 	}
 
 	let style = $derived.by(() => {
-		let _tags = tags_cloud.map(tag => tag.checked && tag.label).filter(Boolean);
-		set_item('checked_tags', _tags);
+		let selected_tags = tags_cloud.reduce((all, tag) => {
+			if (tag.checked) {
+				all[tag.label] = tag.inverted;
+			}
+			return all;
+		}, {});
+		set_item('checked_tags', selected_tags);
 
-		if (!_tags.length) {
+		let include_tags = tags_cloud.filter(tag => tag.checked && !tag.inverted).map(tag => tag.label);
+		let exclude_tags = tags_cloud.filter(tag => tag.checked && tag.inverted).map(tag => tag.label);
+
+		if (!include_tags.length && !exclude_tags.length) {
 			return '';
 		}
 
-		let selectors = get_selectors(_tags);
-		if (is_exclude) {
-			return flat_group_style + selectors + `{ display:none !important; }`;
+		let style = include_tags.length
+			? ordered_style + get_selectors(include_tags) + `{ display:flex; }`
+			: flat_group_style;
+
+		if (exclude_tags.length) {
+			style += get_selectors(exclude_tags) + `{ display:none !important; }`;
 		}
-		return ordered_style + selectors + `{ display:flex; }`;
+		return style;
 	});
 
 	function reset_tags() {
 		is_cap = false;
-		is_exclude = false;
 		tags_cloud.forEach(tag => {
 			tag.checked = false;
+			tag.inverted = false;
 		})
 	}
 
@@ -67,22 +132,12 @@
 	<summary class="text-align:center hide-for-print opacity:0 transition:opacity|.3s"
 		accesskey="t">
 		🔖 {$_('tag')}
-	<span class="display:inline-flex gap:.25em margin:.5em|auto">
-		<label class="display:inline-flex width:fit-content">
-			<input class="switcher" type="checkbox" data-inactive="∪" data-active="∩"
-				title={is_cap ? $_('tag.intersection_selected') : $_('tag.union_selected')}
-				aria-label={is_cap ? $_('tag.intersection_selected') : $_('tag.union_selected')}
-				bind:checked={is_cap}
-			/>
-		</label>
-		<label class="display:inline-flex width:fit-content">
-			<input class="switcher" type="checkbox" data-inactive="show" data-active="hide"
-				title={is_exclude ? $_('tag.hide_selected') : $_('tag.show_selected')}
-				aria-label={is_exclude ? $_('tag.hide_selected') : $_('tag.show_selected')}
-				bind:checked={is_exclude}
-			/>
-		</label>
-	</span>
+	<label class="display:inline-flex width:fit-content margin:.5em|auto">
+		<input class="switcher" type="checkbox" data-inactive="∪" data-active="∩"
+			title={is_cap ? $_('tag.intersection_selected') : $_('tag.union_selected')}
+			bind:checked={is_cap}
+		/>
+	</label>
 	</summary>
 
 
@@ -106,14 +161,15 @@
 					font-weight:900"
 					title="count:{tag.count}"
 				>
-					<input type="checkbox" class="sr-only-u" bind:checked={tag.checked}>
-					{tag.label}
+					<input type="checkbox" class="sr-only-u" bind:checked={tag.checked} onchange={() => sync_tag(tag)}>
+					{get_tag_display_label(tag)}
 					<!-- <sup>({tag.count})</sup> -->
 				</label>
 			{/each}
 
 			<div class="border-right:1px|dotted height:1em align-self:center"></div>
 
+			<input type="button" value={$_('tag.invert')} onclick={invert_tags}>
 			<input type="reset" onclick={reset_tags}>
 		</div>
 		<svelte:element this={style_tag}>{style}</svelte:element>
@@ -133,7 +189,6 @@
 		font-family: inherit;
 		font-size: smaller;
 		cursor: pointer;
-		line-height: 1.2;
 
 		&::after,
 		&::before {

--- a/src/lib/i18n.js
+++ b/src/lib/i18n.js
@@ -61,6 +61,14 @@ let _words = {
 		'en': 'Union - [Intersection]',
 		'zh': '聯集 [交集]',
 	},
+	'tag.show_selected': {
+		'en': '[Show] - Hide',
+		'zh': '[顯示] 隱藏',
+	},
+	'tag.hide_selected': {
+		'en': 'Show - [Hide]',
+		'zh': '顯示 [隱藏]',
+	},
 	'record': {
 		'en': 'Record',
 		'zh': '紀錄',

--- a/src/lib/i18n.js
+++ b/src/lib/i18n.js
@@ -61,13 +61,9 @@ let _words = {
 		'en': 'Union - [Intersection]',
 		'zh': '聯集 [交集]',
 	},
-	'tag.show_selected': {
-		'en': '[Show] - Hide',
-		'zh': '[顯示] 隱藏',
-	},
-	'tag.hide_selected': {
-		'en': 'Show - [Hide]',
-		'zh': '顯示 [隱藏]',
+	'tag.invert': {
+		'en': 'Invert',
+		'zh': '反選',
 	},
 	'record': {
 		'en': 'Record',

--- a/src/lib/pm.svelte.js
+++ b/src/lib/pm.svelte.js
@@ -180,9 +180,6 @@ export function get_name(names, lang = 'en') {
 }
 
 function get_default_tags(tags = [], pid = '', dex = 1) {
-	if (!tags.includes('costume')) {
-		tags.push('-costume');
-	}
 	switch (pid.split('.f')[1]) {
 		case 'HISUIAN':
 			tags.push('📍hisuian');

--- a/src/lib/u.js
+++ b/src/lib/u.js
@@ -152,4 +152,5 @@ export const flat_group_style = `
 export const ordered_style = flat_group_style + `
 .pm-group .pm {
 	display: none;
+	order: var(--dex-order);
 }`;

--- a/src/lib/u.js
+++ b/src/lib/u.js
@@ -138,7 +138,7 @@ export function preventDefault(fn) {
 	};
 }
 
-export const ordered_style = `
+export const flat_group_style = `
 .pm-list {
 	gap: 1em;
 }
@@ -146,6 +146,10 @@ export const ordered_style = `
 	display: contents !important;
 }
 .pm-group .pm {
-	display: none;
 	order: var(--dex-order);
+}`;
+
+export const ordered_style = flat_group_style + `
+.pm-group .pm {
+	display: none;
 }`;


### PR DESCRIPTION
I despise the hatch-only babies :-) 

## Summary

This adds two improvements to tag filtering:

- add a `show / hide` toggle in the tag panel so selected tags can be used to exclude matching Pokemon from view
~~- add a derived `-BABY` complement tag, similar to the existing `-COSTUME` tag behavior~~

## Details

- keep the existing union/intersection tag matching logic
- apply that logic to both include and exclude filtering
- persist the new hide mode in local storage
- add UI labels for the new show/hide toggle
~~- derive `-BABY` for non-baby species in the data pipeline~~
