### PR TITLE
feat: add -baby complement tag

### DIFF
--- a/src/lib/pm.svelte.js
+++ b/src/lib/pm.svelte.js
@@ -183,6 +183,9 @@ function get_default_tags(tags = [], pid = '', dex = 1) {
 	if (!tags.includes('costume')) {
 		tags.push('-costume');
 	}
+	if (!tags.includes('baby')) {
+		tags.push('-baby');
+	}
 	switch (pid.split('.f')[1]) {
 		case 'HISUIAN':
 			tags.push('📍hisuian');


### PR DESCRIPTION
## Summary

- add a derived `-baby` complement tag for rows that do not already have the `baby` tag

## Details

- mirror the existing `-costume` complement pattern
- derive `-baby` directly from the spreadsheet's existing `baby` tag
