### PR TITLE
feat: add default PM source preset in custom config

### DIFF
--- a/src/component/Custom.svelte
+++ b/src/component/Custom.svelte
@@ -2,8 +2,17 @@
 	import { _, locale, locales } from 'svelte-i18n';
 	import { config, default_config } from '@/stores.js';
 
+	const pm_source_url = {
+		type: 'json',
+		url: 'https://opensheet.elk.sh/1l1CXHdge8_2F2ifjMY71f23DJ_98Ei2QNZ9rPdBd8jQ/pm',
+	};
+
 	function reset_data_source() {
 		$config.source_url = {...default_config.source_url};
+	}
+
+	function use_pm_data_source() {
+		$config.source_url = {...pm_source_url};
 	}
 
 	function reset_all_config() {
@@ -79,8 +88,11 @@
 
 		<hr>
 
-		<div class="display:flex">
-			<button class="margin:auto" onclick={reset_all_config}>
+		<div class="action-buttons">
+			<button onclick={use_pm_data_source}>
+				{$_('custom.use_pm_source_url')}
+			</button>
+			<button onclick={reset_all_config}>
 				{$_('custom.reset_all_config')}
 			</button>
 		</div>
@@ -95,5 +107,12 @@
 		&::marker {
 			content: attr(data-marker) ' ';
 		}
+	}
+
+	.action-buttons {
+		display: flex;
+		gap: 0.5em;
+		justify-content: center;
+		flex-wrap: wrap;
 	}
 </style>

--- a/src/component/Custom.svelte
+++ b/src/component/Custom.svelte
@@ -70,7 +70,7 @@
 
 				<div>
 					pms:
-					<label class="display:flex gap:.25em">
+					<label class="display:flex gap:.25em margin-bottom:.5em">
 						<!-- https://api.npoint.io/6acfd46ce5bfdbca61af -->
 						<input type="text"
 							class="width:4em flex-grow:1"
@@ -81,7 +81,8 @@
 							<option value="json">json</option>
 						</select>
 					</label>
-					<div class="source-actions">
+
+					<div class="display:flex gap:.5em justify-content:flex-end">
 						<button type="button" onclick={use_pm_data_source}>
 							{$_('custom.default')}
 						</button>
@@ -110,12 +111,4 @@
 			content: attr(data-marker) ' ';
 		}
 	}
-
-	.source-actions {
-		display: flex;
-		gap: 0.5em;
-		margin-top: 0.5em;
-		justify-content: flex-end;
-	}
-
 </style>

--- a/src/component/Custom.svelte
+++ b/src/component/Custom.svelte
@@ -80,6 +80,9 @@
 							<option value="csv">csv</option>
 							<option value="json">json</option>
 						</select>
+						<button type="button" onclick={use_pm_data_source}>
+							{$_('custom.default')}
+						</button>
 						<input type="reset" onclick={reset_data_source}>
 					</label>
 				</div>
@@ -88,11 +91,8 @@
 
 		<hr>
 
-		<div class="action-buttons">
-			<button onclick={use_pm_data_source}>
-				{$_('custom.use_pm_source_url')}
-			</button>
-			<button onclick={reset_all_config}>
+		<div class="display:flex">
+			<button class="margin:auto" onclick={reset_all_config}>
 				{$_('custom.reset_all_config')}
 			</button>
 		</div>
@@ -109,10 +109,4 @@
 		}
 	}
 
-	.action-buttons {
-		display: flex;
-		gap: 0.5em;
-		justify-content: center;
-		flex-wrap: wrap;
-	}
 </style>

--- a/src/component/Custom.svelte
+++ b/src/component/Custom.svelte
@@ -70,7 +70,7 @@
 
 				<div>
 					pms:
-					<label class="display:flex gap:.25em margin-bottom:.5em">
+					<label class="display:flex gap:.25em">
 						<!-- https://api.npoint.io/6acfd46ce5bfdbca61af -->
 						<input type="text"
 							class="width:4em flex-grow:1"
@@ -80,11 +80,13 @@
 							<option value="csv">csv</option>
 							<option value="json">json</option>
 						</select>
+					</label>
+					<div class="source-actions">
 						<button type="button" onclick={use_pm_data_source}>
 							{$_('custom.default')}
 						</button>
 						<input type="reset" onclick={reset_data_source}>
-					</label>
+					</div>
 				</div>
 			</details>
 		</li>
@@ -107,6 +109,13 @@
 		&::marker {
 			content: attr(data-marker) ' ';
 		}
+	}
+
+	.source-actions {
+		display: flex;
+		gap: 0.5em;
+		margin-top: 0.5em;
+		justify-content: flex-end;
 	}
 
 </style>

--- a/src/lib/i18n.js
+++ b/src/lib/i18n.js
@@ -175,9 +175,9 @@ let _words = {
 		'en': 'Custom data source url',
 		'zh': '自訂資料網址',
 	},
-	'custom.use_pm_source_url': {
-		'en': 'Use PM sheet url',
-		'zh': '使用 PM 表格網址',
+	'custom.default': {
+		'en': 'Default',
+		'zh': '預設',
 	},
 	'custom.reset_all_config': {
 		'en': 'RESET all config',

--- a/src/lib/i18n.js
+++ b/src/lib/i18n.js
@@ -175,6 +175,10 @@ let _words = {
 		'en': 'Custom data source url',
 		'zh': '自訂資料網址',
 	},
+	'custom.use_pm_source_url': {
+		'en': 'Use PM sheet url',
+		'zh': '使用 PM 表格網址',
+	},
 	'custom.reset_all_config': {
 		'en': 'RESET all config',
 		'zh': '重置全部設定',


### PR DESCRIPTION
## Introduction
Frequently custom config is reset either on purpose or by accident. Since most users will defaults to using the "community" spreadsheet that you started, a quick way to set that is needed.

## Summary
- add a `Default` button for the PM custom source
- set the PM opensheet URL and `json` type when that button is used
- place the source action buttons on their own row below the custom URL controls
- keep `RESET all config` separate as the global reset action

## Known Issues
- I am aware that hardcoding a PMS json URL for a Google Sheet is a brittle implementation, however, I believe that convenience is warranted. The PMS spreadsheet is the defacto database that I am heavily maintaining and anticipated to be widely used much more so than individuals creating their own spreadsheet.
 
## Testing
- verified locally via my disposable live review branch
- confirmed the updated custom panel layout in local preview
