### PR TITLE
fix: support sparse Order overrides

### DIFF
--- a/src/component/Item.svelte
+++ b/src/component/Item.svelte
@@ -29,7 +29,7 @@
 	class:img_diff={$config.img_diff}
 	data-index={pm.index}
 	onclick={() => handle_click_pm(pm.index)}
-	style="--group-order:{pm.order || 0};--dex-order:{pm.dex};"
+	style="--group-order:{pm.sort_order};--dex-order:{pm.dex};"
 	title={title}
 >
 	<div class="img-box"

--- a/src/lib/pm.svelte.js
+++ b/src/lib/pm.svelte.js
@@ -103,11 +103,15 @@ export function handle_pms(pms_json) {
 			pm.suffix = pm.suffix.replace(/\|/g, '\n');
 		}
 
+		let order = get_defined_order(pm.order);
+
 		let op_pm = {
 			...pm,
+			order,
 			index,
 			dex,
 			name: names[dex],
+			sort_order: order ?? index,
 			time_order: +new Date(pm.debut) / 1000 + dex,
 			// costume: pm.pid.includes('.'),
 			// shiny: new Date(pm.debut) < today,
@@ -148,10 +152,23 @@ export function handle_pms(pms_json) {
 					pids: [],
 					pms: [],
 					root_groups: [],
+					min_dex: dex,
+					sort_index: index,
+					sort_order: op_pm.sort_order,
 				};
 			}
-			_root.groups[_group_index].pids.push(pm.pid);
-			_root.groups[_group_index].pms.push(op_pm);
+			let group = _root.groups[_group_index];
+			group.pids.push(pm.pid);
+			group.pms.push(op_pm);
+			group.min_dex = Math.min(group.min_dex, dex);
+
+			if (
+				op_pm.sort_order < group.sort_order ||
+				(op_pm.sort_order === group.sort_order && index < group.sort_index)
+			) {
+				group.sort_order = op_pm.sort_order;
+				group.sort_index = index;
+			}
 		}
 
 		return op_pm;
@@ -161,15 +178,14 @@ export function handle_pms(pms_json) {
 	root_map = null;
 	root_index_map = null;
 
-	let sort_by_min_dex = (a, b) => {
-		let minA = Math.min(...a.pms.map(p => p.dex)) || 0;
-		let minB = Math.min(...b.pms.map(p => p.dex)) || 0;
-		return minA - minB;
-	};
+	let groups = all_groups.map(i => i.groups).flat();
+	groups.forEach(group => {
+		group.pms.sort(sort_by_effective_order);
+	});
 
 	return {
 		pms,
-		groups: all_groups.map(i => i.groups).flat().sort(sort_by_min_dex),
+		groups: groups.sort(sort_groups),
 		max_index,
 		tags,
 	};
@@ -177,6 +193,37 @@ export function handle_pms(pms_json) {
 
 export function get_name(names, lang = 'en') {
 	return names?.[lang] || names?.en || '';
+}
+
+function get_defined_order(order) {
+	if (order === '' || order === undefined || order === null) {
+		return undefined;
+	}
+
+	let op = Number(order);
+	return Number.isFinite(op) ? op : undefined;
+}
+
+function sort_by_effective_order(a, b) {
+	let orderA = a.sort_order ?? a.index ?? 0;
+	let orderB = b.sort_order ?? b.index ?? 0;
+
+	if (orderA !== orderB) {
+		return orderA - orderB;
+	}
+
+	return (a.index ?? a.sort_index ?? 0) - (b.index ?? b.sort_index ?? 0);
+}
+
+function sort_groups(a, b) {
+	let minA = a.min_dex || 0;
+	let minB = b.min_dex || 0;
+
+	if (minA !== minB) {
+		return minA - minB;
+	}
+
+	return sort_by_effective_order(a, b);
 }
 
 function get_default_tags(tags = [], pid = '', dex = 1) {


### PR DESCRIPTION
## Summary
- fix a bug where blank `order` did not fall back to `index` as documented in the README
- use the same effective sort key for subgroup placement and item placement
- preserve `index` as the tie-breaker

## Why
A few PM sheet entries need to move relative to nearby costume groups without renumbering an entire block. The existing implementation made sparse `order` values hard to use because blank values did not behave the way the README describes, and subgroup placement did not follow the same effective ordering as items within a subgroup.

## Notes
- Default behavior is unchanged for entries without an `order` value; they continue to sort by `index`.
- This is intended as a narrow bugfix rather than a broader change to release-date ordering which I considered.
- The README describes blank `order` as falling back to `index`, but the previous item rendering path effectively treated blank values as `0` (bug).
- The current PM sheet now uses sparse decimal overrides for the specific exceptions that prompted this change, for example `pm25.cFEB_2019` at `64.5` and `pm25.cPI` / `pm26.cPI` at `1222.5`.
- Verified locally against the custom PM spreadsheet in my local live dev review workflow.
