### PR TITLE
Fix Owned total to include Extra

### DIFF
--- a/src/component/Head.svelte
+++ b/src/component/Head.svelte
@@ -78,7 +78,7 @@
 					>
 
 					<div class="number font-size:1.2rem">
-						{status_counter[index]}
+						{index === 2 ? counts.own.summary : status_counter[index]}
 					</div>
 					<div class="white-space:nowrap overflow:hidden text-overflow:ellipsis width:100% padding:0|2 margin-top:.25em font-size:smaller text-transform:capitalize opacity:0.5">
 						{$_(`status.${status_labels[index]}`)}

--- a/src/component/Head.svelte
+++ b/src/component/Head.svelte
@@ -78,6 +78,7 @@
 					>
 
 					<div class="number font-size:1.2rem">
+						<!-- workaround pull#77 -->
 						{index === 2 ? counts.own.summary : status_counter[index]}
 					</div>
 					<div class="white-space:nowrap overflow:hidden text-overflow:ellipsis width:100% padding:0|2 margin-top:.25em font-size:smaller text-transform:capitalize opacity:0.5">


### PR DESCRIPTION
## Summary
- fix the header Owned total to include entries marked Extra
- reuse the existing owned summary so the Owned tile matches the header progress calculation

## Bug
The dashboard was showing the Owned tile from raw `status_counter[2]`, which excluded status `3` (`Extra`) even though `Extra` is already treated as owned elsewhere in the header.

## Testing
I tested this in my local dev setup and after bug fix, the Owned total is as expected; including Extra