### PR TITLE
fix: left align suffix captions

### DIFF
--- a/src/component/Item.svelte
+++ b/src/component/Item.svelte
@@ -169,6 +169,8 @@
 
 	.name {
 		font-size: 10px;
+		padding-left: 1px;
+		text-align: left;
 		opacity: 0.4;
 		transition: opacity 0.3s;
 


### PR DESCRIPTION
## Summary
- left align suffix captions in the item name block
- add 1px left padding so the first line does not sit too far left (and matched original 'single-row' alignment)

## Testing
- verified the alignment behavior in local review

## Before:
<img width="1056" height="514" alt="Screenshot 2026-04-22 at 11 38 25 AM" src="https://github.com/user-attachments/assets/b806127a-74e8-4cea-b51b-4b95bfedfe64" />

## After:
<img width="1056" height="514" alt="Screenshot 2026-04-22 at 11 37 58 AM" src="https://github.com/user-attachments/assets/0dd0a3c3-1533-427a-aa9f-bce25c9e2381" />