### PR TITLE
fix: remember filter state after reload

### DIFF
--- a/src/lib/filter.svelte.js
+++ b/src/lib/filter.svelte.js
@@ -1,4 +1,5 @@
 import { pokemonStore, } from '@lib/pm.svelte.js';
+import { get_item, set_item, } from '@lib/u.svelte.js';
 
 const custom_style_when_filtered = `
 .pm-list {
@@ -13,7 +14,7 @@ const custom_style_when_filtered = `
 
 class FilterManager {
 	filter_cates = ['🧬', '📍', '🐣', '🧩'];
-	filter_state = $state({});
+	filter_state = $state(get_item('filter_state') || {});
 
 	reset_filter() {
 		console.log(111, 'reset');
@@ -97,3 +98,9 @@ class FilterManager {
 }
 
 export const filter_manager = new FilterManager();
+
+$effect.root(() => {
+	$effect(() => {
+		set_item('filter_state', $state.snapshot(filter_manager.filter_state));
+	});
+});


### PR DESCRIPTION
Closes #91 ... if you think this is acceptable :-) 

## Summary

Implements persistence of the tag filter state across page reloads, closing #91.

Previously, any tag filters the user had active (include ➕ or exclude ⛔) were lost on reload — the `filter_state` object always initialized as `{}`. This change wires `filter_state` into the existing `localStorage` utility so the filter panel reflects exactly what the user left it at.

## Changes

- **`src/lib/filter.svelte.js`**
  - Imports `get_item` / `set_item` from `@lib/u.svelte.js`
  - Initializes `filter_state` from `get_item('filter_state')` with `{}` fallback
  - Adds a `$effect.root` block that snapshots and persists `filter_state` to localStorage on every change
  - The existing `reset_filter()` method sets `filter_state = {}`, which triggers the effect and clears storage automatically — no extra handling needed

## Approach

Follows the identical pattern already established in `config.svelte.js`:
- Load from `get_item(key)` at initialization
- Persist via `$effect.root(() => { $effect(() => { set_item(...) }) })`

No new storage keys introduced beyond the existing `pm-shiny-26` localStorage entry (the key `filter_state` is added as a nested property, consistent with how `ctrl_io` and `config` are stored).
