### PR TITLE
fix: registered count includes owned pokémon

### DIFF
--- a/src/lib/pm.svelte.js
+++ b/src/lib/pm.svelte.js
@@ -66,7 +66,7 @@ class PokemonManager {
 		const counts = this.status_counts;
 		return [
 			{ label: 'none',  count: counts[0], },
-			{ label: 'met',   count: counts[1], },
+			{ label: 'met',   count: counts[1] + counts[2] + counts[3], },
 			{ label: 'own',   count: counts[2] + counts[3], },
 			{ label: 'extra', count: counts[3], },
 		];


### PR DESCRIPTION
## Summary

- Fixes #94
- The "Registered" counter was only counting Pokémon at status 1 (met/seen), so clicking "Owned" would remove a Pokémon from the Registered count
- Status 2 (own) and 3 (extra) both imply prior registration — if you own it, you registered it first
- Fix mirrors how the existing "Owned" count already includes status 3: `counts[2] + counts[3]`

**Before:** Registered = status 1 only → Owned could exceed Registered  
**After:** Registered = status 1 + 2 + 3 → Registered ≥ Owned always holds

## Change

One line in `src/lib/pm.svelte.js`:

```js
// before
{ label: 'met', count: counts[1], },
// after
{ label: 'met', count: counts[1] + counts[2] + counts[3], },
```

## Test plan

- [ ] Mark a Pokémon as Owned — Registered count should stay the same or increase, never decrease
- [ ] Mark a Pokémon as Extra — same check
- [ ] Registered count ≥ Owned count at all times