### PR TITLE
Save main filter state in shared URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,10 @@ Our data status example for 3 families:
 
 This represents our data status format.
 
+The shared URL can also include a `visibility` parameter for the four main
+filters in order: Unregistered, Registered, Owned, Extra. Use `1` for visible
+and `0` for hidden. For example, `visibility=1000` shows Unregistered only.
+
 all csv columns/properties:
 
 | property | required? | type | description |

--- a/src/component/Record.svelte
+++ b/src/component/Record.svelte
@@ -1,6 +1,6 @@
 <script>
 	import { recorder, } from '@lib/recorder.svelte.js';
-	import { session } from '@lib/config.svelte.js';
+	import { config, session } from '@lib/config.svelte.js';
 	import { get_time_string, gen_href, } from '@lib/u.svelte.js';
 	import { i18n } from '@lib/i18n.svelte.js';
 	import { pokemonStore, } from '@lib/pm.svelte.js';
@@ -34,7 +34,7 @@
 
 				<div class="label">
 					<a class="link {record.name === session.name && 'bolder'}"
-						href={gen_href(record.status, record.name)}
+						href={gen_href(record.status, record.name, config.status_visibility)}
 						onclick={(e) => click_record(e, index, record)}
 					>
 						<div>

--- a/src/component/Share.svelte
+++ b/src/component/Share.svelte
@@ -1,10 +1,10 @@
 <script>
 	import { i18n } from '@lib/i18n.svelte.js';
-	import { session } from '@lib/config.svelte.js';
+	import { config, session } from '@lib/config.svelte.js';
 	import { pokemonStore, } from '@lib/pm.svelte.js';
 	import { fetch_data, gen_href, } from '@lib/u.svelte.js';
 
-	let url = $derived(gen_href(pokemonStore.status_string, session.name));
+	let url = $derived(gen_href(pokemonStore.status_string, session.name, config.status_visibility));
 
 	let short_href = $state(null);
 

--- a/src/lib/config.svelte.js
+++ b/src/lib/config.svelte.js
@@ -59,6 +59,7 @@ export const config = $state({
 	if (_status_visibility) {
 		config.status_visibility = _status_visibility;
 	} else if (_status) {
+		// Old shared status URLs did not include visibility, so keep their all-visible behavior.
 		config.status_visibility = parse_status_visibility('1111');
 	}
 

--- a/src/lib/config.svelte.js
+++ b/src/lib/config.svelte.js
@@ -58,9 +58,6 @@ export const config = $state({
 
 	if (_status_visibility) {
 		config.status_visibility = _status_visibility;
-	} else if (_status) {
-		// Old shared status URLs did not include visibility, so keep their all-visible behavior.
-		config.status_visibility = parse_status_visibility('1111');
 	}
 
 	history.replaceState({}, null, location.pathname); // reset qs

--- a/src/lib/config.svelte.js
+++ b/src/lib/config.svelte.js
@@ -1,5 +1,5 @@
 import pm_local_csv_url from '@data/pm.csv?url';
-import { set_item, get_item, } from '@lib/u.svelte.js';
+import { set_item, get_item, parse_status_visibility, } from '@lib/u.svelte.js';
 
 // export let status = $state('');
 // export let name = $state('?');
@@ -46,6 +46,25 @@ export const config = $state({
 	...get_item('config'),
 });
 
+{
+	const _qs = new URL(location).searchParams;
+	const _status = _qs.get('status') || '';
+	const _status_visibility = parse_status_visibility(_qs.get('visibility') || '');
+
+	if (_status) {
+		session.status = _status;
+		session.name = _qs.get('name') || '?';
+	}
+
+	if (_status_visibility) {
+		config.status_visibility = _status_visibility;
+	} else if (_status) {
+		config.status_visibility = parse_status_visibility('1111');
+	}
+
+	history.replaceState({}, null, location.pathname); // reset qs
+}
+
 let _save_timer;
 
 // 2. Auto-persist on any change
@@ -85,15 +104,6 @@ $effect.root(() => {
 		}, 500); // Wait for 500ms of inactivity
 	});
 });
-
-{
-	const _qs = new URL(location).searchParams;
-	if (_qs.get('status')) {
-		session.status = _qs.get('status') || '';
-		session.name = _qs.get('name') || '?';
-		history.pushState({}, null, location.pathname); // reset qs
-	}
-}
 
 export function reset_all_config() {
 	const fresh_default = JSON.parse(JSON.stringify(DEFAULT_CONFIG));

--- a/src/lib/u.svelte.js
+++ b/src/lib/u.svelte.js
@@ -64,11 +64,29 @@ export function confirm_to_reset() {
 	}
 }
 
-export function gen_href(status, name) {
+export function parse_status_visibility(value = '') {
+	if (!/^[01]{4}$/.test(value)) {
+		return null;
+	}
+
+	return value.split('').map(v => v === '1');
+}
+
+export function stringify_status_visibility(status_visibility = []) {
+	return status_visibility
+		.slice(0, 4)
+		.map(v => v ? '1' : '0')
+		.join('');
+}
+
+export function gen_href(status, name, status_visibility) {
 	let a = new URL(location.href);
 	a.hash = '';
 	a.searchParams.set('name', name);
 	a.searchParams.set('status', status);
+	if (status_visibility) {
+		a.searchParams.set('visibility', stringify_status_visibility(status_visibility));
+	}
 
 	return a.toString();
 }

--- a/src/lib/u.svelte.js
+++ b/src/lib/u.svelte.js
@@ -65,18 +65,18 @@ export function confirm_to_reset() {
 }
 
 export function parse_status_visibility(value = '') {
-	if (!/^[01]{4}$/.test(value)) {
+	if (value.length !== 4 || !/^[01]{4}$/.test(value)) {
 		return null;
 	}
-
-	return value.split('').map(v => v === '1');
+	return Array.from(value, v => v === '1');
 }
 
 export function stringify_status_visibility(status_visibility = []) {
-	return status_visibility
-		.slice(0, 4)
-		.map(v => v ? '1' : '0')
-		.join('');
+	let res = '';
+	for (let i = 0; i < 4; i++) {
+		res += status_visibility[i] ? '1' : '0';
+	}
+	return res;
 }
 
 export function gen_href(status, name, status_visibility) {


### PR DESCRIPTION
## Summary
- add a compact `visibility` query parameter for the main filter toggles
- restore shared filter visibility from incoming URLs
- keep old `status=` URLs backward compatible by treating missing visibility as all filters ON
- document the shared URL visibility format

Closes #96

I don't have an easy way to fully test this but the code changes are pretty minor. Let me know what you think!