### PR TITLE
Handle invalidated debut rows to allow for existing row to be 'removed'

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,9 +95,9 @@ all csv columns/properties:
 | `style`  | -        | string | custom image style,<br>e.q. `--w:140%;--l:-10%;--t:-10%;`
 | `src`    | -        | string | image url, custom image source, will overwrite the image of pid <br> could be https://ooxx.png |
 
-For `debut`, leave the cell blank for unreleased or unused future data. Use a
-nonblank non-date value only when an existing row should be hidden without
-shifting saved status URL indexes.
+A blank `debut` value is ignored and does not reserve a status URL position.
+Use a nonblank non-date value only when an existing row should be hidden
+without shifting saved status URL indexes.
 
 
 ※ If you use custom `src`, and try to create a custom `pid`, just follow basic format rules:

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ all csv columns/properties:
 | property | required? | type | description |
 | -------- | -------- | ----- | ----- |
 | `family_dex`  | required | number | usally the pokedex of the first pokemon of family,<br>please group together data rows with the same family_dex |
-| `debut`  | required | string | shiny form released date |
+| `debut`  | required | string | shiny form released date.<br>A nonblank value that is not a valid date invalidates the row: the row is not displayed, but its status URL position is preserved. |
 | `pid`    | required | string | uni key, image file name.<br>format: `pm25.cFALL_2018`... |
 | `group`  | required | string | A flexible string used for grouping; <br>this will be used to sort the groups, and you may append a numeric suffix when needed to adjust the group order." |
 | `tag`    | -        | string | tags for pokemon, combine tags with `=`.<br> e.q. `tag1=tag2=tag3` |
@@ -94,6 +94,10 @@ all csv columns/properties:
 | `suffix` | -        | string | suffix name, write mega or other types.<br>e.q. `(Y)`, `#7` |
 | `style`  | -        | string | custom image style,<br>e.q. `--w:140%;--l:-10%;--t:-10%;`
 | `src`    | -        | string | image url, custom image source, will overwrite the image of pid <br> could be https://ooxx.png |
+
+For `debut`, leave the cell blank for unreleased or unused future data. Use a
+nonblank non-date value only when an existing row should be hidden without
+shifting saved status URL indexes.
 
 
 ※ If you use custom `src`, and try to create a custom `pid`, just follow basic format rules:

--- a/src/lib/pm.svelte.js
+++ b/src/lib/pm.svelte.js
@@ -10,7 +10,7 @@ class PokemonManager {
 	is_loading = $state(true);
 	error = $state(null);
 	pid_with_tags = $state(new Map());
-	status_slots = $state(new Map());
+	status_length_in_family = $state(new Map());
 
 	async init() {
 		this.is_loading = true;
@@ -18,12 +18,12 @@ class PokemonManager {
 
 		try {
 			// Step 1: Basic setup
-			const { groups, tags, pid_with_tags, status_slots } = await fetch_pms_data();
+			const { groups, tags, pid_with_tags, status_length_in_family } = await fetch_pms_data();
 
 			this.groups = groups;
 			this.tags = tags;
 			this.pid_with_tags = pid_with_tags;
-			this.status_slots = status_slots;
+			this.status_length_in_family = status_length_in_family;
 
 			// Step 2: Data priority logic (The core sequence)
 			// Priority 1: URL session (already parsed in config.svelte.js)
@@ -88,7 +88,8 @@ class PokemonManager {
 
 		this.sorted_pms.forEach(pm => {
 			if (!grouped_map.has(pm._gidx)) {
-				grouped_map.set(pm._gidx, Array(this.status_slots.get(pm._gidx) || pm._pidx + 1).fill(0));
+				const _array_len = this.status_length_in_family.get(pm._gidx) || (pm._pidx + 1);
+				grouped_map.set(pm._gidx, Array(_array_len).fill(0));
 			}
 			grouped_map.get(pm._gidx)[pm._pidx] = pm.status ?? 0;
 		});
@@ -188,7 +189,7 @@ function handle_pms(pms) {
 	const all_groups = new Map();
 	const tags = {};
 	const pid_with_tags = new Map();
-	const status_slots = new Map();
+	const status_length_in_family = new Map();
 
 	let _fdex = 0;
 	let _fcounter = 0;
@@ -217,7 +218,7 @@ function handle_pms(pms) {
 			pm._pidx = Number(_fcounter - 1);
 			// pm.key = `${pm.family_dex}.${_fcounter}`;
 		}
-		status_slots.set(pm._gidx, Math.max(status_slots.get(pm._gidx) || 0, pm._pidx + 1));
+		status_length_in_family.set(pm._gidx, Math.max(status_length_in_family.get(pm._gidx) || 0, pm._pidx + 1));
 
 		if (is_tombstone) {
 			return;
@@ -271,7 +272,7 @@ function handle_pms(pms) {
 		groups: Array.from(all_groups).sort(sort_by_group_id),
 		tags,
 		pid_with_tags,
-		status_slots,
+		status_length_in_family,
 	};
 }
 

--- a/src/lib/pm.svelte.js
+++ b/src/lib/pm.svelte.js
@@ -10,7 +10,7 @@ class PokemonManager {
 	is_loading = $state(true);
 	error = $state(null);
 	pid_with_tags = $state(new Map());
-	status_length_in_family = $state(new Map());
+	status_length_by_family = $state(new Map());
 
 	async init() {
 		this.is_loading = true;
@@ -18,12 +18,12 @@ class PokemonManager {
 
 		try {
 			// Step 1: Basic setup
-			const { groups, tags, pid_with_tags, status_length_in_family } = await fetch_pms_data();
+			const { groups, tags, pid_with_tags, status_length_by_family } = await fetch_pms_data();
 
 			this.groups = groups;
 			this.tags = tags;
 			this.pid_with_tags = pid_with_tags;
-			this.status_length_in_family = status_length_in_family;
+			this.status_length_by_family = status_length_by_family;
 
 			// Step 2: Data priority logic (The core sequence)
 			// Priority 1: URL session (already parsed in config.svelte.js)
@@ -88,7 +88,7 @@ class PokemonManager {
 
 		this.sorted_pms.forEach(pm => {
 			if (!grouped_map.has(pm._gidx)) {
-				const _array_len = this.status_length_in_family.get(pm._gidx) || (pm._pidx + 1);
+				const _array_len = this.status_length_by_family.get(pm._gidx);
 				grouped_map.set(pm._gidx, Array(_array_len).fill(0));
 			}
 			grouped_map.get(pm._gidx)[pm._pidx] = pm.status ?? 0;
@@ -189,7 +189,7 @@ function handle_pms(pms) {
 	const all_groups = new Map();
 	const tags = {};
 	const pid_with_tags = new Map();
-	const status_length_in_family = new Map();
+	const status_length_by_family = new Map();
 
 	let _fdex = 0;
 	let _fcounter = 0;
@@ -218,7 +218,8 @@ function handle_pms(pms) {
 			pm._pidx = Number(_fcounter - 1);
 			// pm.key = `${pm.family_dex}.${_fcounter}`;
 		}
-		status_length_in_family.set(pm._gidx, Math.max(status_length_in_family.get(pm._gidx) || 0, pm._pidx + 1));
+		// Reserve the original family status position before tombstone rows are skipped.
+		status_length_by_family.set(pm._gidx, Math.max(status_length_by_family.get(pm._gidx) || 0, pm._pidx + 1));
 
 		if (is_tombstone) {
 			return;
@@ -272,7 +273,7 @@ function handle_pms(pms) {
 		groups: Array.from(all_groups).sort(sort_by_group_id),
 		tags,
 		pid_with_tags,
-		status_length_in_family,
+		status_length_by_family,
 	};
 }
 

--- a/src/lib/pm.svelte.js
+++ b/src/lib/pm.svelte.js
@@ -10,6 +10,7 @@ class PokemonManager {
 	is_loading = $state(true);
 	error = $state(null);
 	pid_with_tags = $state(new Map());
+	status_slots = $state(new Map());
 
 	async init() {
 		this.is_loading = true;
@@ -17,11 +18,12 @@ class PokemonManager {
 
 		try {
 			// Step 1: Basic setup
-			const { groups, tags, pid_with_tags } = await fetch_pms_data();
+			const { groups, tags, pid_with_tags, status_slots } = await fetch_pms_data();
 
 			this.groups = groups;
 			this.tags = tags;
 			this.pid_with_tags = pid_with_tags;
+			this.status_slots = status_slots;
 
 			// Step 2: Data priority logic (The core sequence)
 			// Priority 1: URL session (already parsed in config.svelte.js)
@@ -85,8 +87,10 @@ class PokemonManager {
 		const grouped_map = new Map();
 
 		this.sorted_pms.forEach(pm => {
-			if (!grouped_map.has(pm._gidx)) grouped_map.set(pm._gidx, []);
-			grouped_map.get(pm._gidx).push(pm.status ?? 0);
+			if (!grouped_map.has(pm._gidx)) {
+				grouped_map.set(pm._gidx, Array(this.status_slots.get(pm._gidx) || pm._pidx + 1).fill(0));
+			}
+			grouped_map.get(pm._gidx)[pm._pidx] = pm.status ?? 0;
 		});
 		return Array.from(grouped_map, ([key, values]) => `${key}.${values.join('')}`).join('-');
 	});
@@ -184,21 +188,19 @@ function handle_pms(pms) {
 	const all_groups = new Map();
 	const tags = {};
 	const pid_with_tags = new Map();
+	const status_slots = new Map();
 
 	let _fdex = 0;
 	let _fcounter = 0;
 
 	pms.filter(Boolean).forEach(pm => {
-		const debut_timing = +(new Date(pm.debut));
-		if (!(debut_timing < today)) {
+		const debut = (pm.debut || '').trim();
+		const debut_timing = +(new Date(debut));
+		const is_tombstone = debut && Number.isNaN(debut_timing);
+
+		if (!is_tombstone && !(debut_timing < today)) {
 			return;
 		}
-		const dex = +(pm.pid.match(/pm(\d+)/)?.[1]);
-
-		pm.dex = dex;
-		pm.name = names[dex];
-		// pm.time_order = debut_timing / 1000 + dex;
-		pm.status = '0';
 
 		// if (pm.family_dex !== '1' && pm.family_dex !== '422') {
 		// 	return
@@ -215,6 +217,18 @@ function handle_pms(pms) {
 			pm._pidx = Number(_fcounter - 1);
 			// pm.key = `${pm.family_dex}.${_fcounter}`;
 		}
+		status_slots.set(pm._gidx, Math.max(status_slots.get(pm._gidx) || 0, pm._pidx + 1));
+
+		if (is_tombstone) {
+			return;
+		}
+
+		const dex = +(pm.pid.match(/pm(\d+)/)?.[1]);
+
+		pm.dex = dex;
+		pm.name = names[dex];
+		// pm.time_order = debut_timing / 1000 + dex;
+		pm.status = '0';
 
 		{ // tags
 			pm.tag = [...new Set(
@@ -257,6 +271,7 @@ function handle_pms(pms) {
 		groups: Array.from(all_groups).sort(sort_by_group_id),
 		tags,
 		pid_with_tags,
+		status_slots,
 	};
 }
 


### PR DESCRIPTION
## Summary

Closes #98.

This is not a workaround. The bug comes from using the visible Pokemon list as the source of truth for the serialized status layout. Invalidated rows should be hidden from rendering, tags, and counts, but they still need to reserve their original family status index. The proposed PR is a real data-model fix, not a workaround. This handles intentionally invalidated data rows without shifting saved status indexes for later rows in the same `family_dex`.

This change makes that distinction explicit: visible rows continue to drive the UI, while `status_slots` preserves the full per-family status layout needed for stable saved URLs.

This change makes that distinction explicit: visible rows continue to drive the UI, while `status_slots` preserves the full per-family status layout needed for stable saved URLs.

Rows with a non-blank, invalid `debut` value are preserved with a reserved status slot:
- they keep their original family status position
- they are omitted from rendered groups, tags, and counts
- generated status URLs preserve alignment by writing `0` for the reserved slot
