### PR TITLE
Increase floating button touch targets

### DIFF
--- a/src/component/Float_Btns.svelte
+++ b/src/component/Float_Btns.svelte
@@ -31,11 +31,26 @@
 
 <style>
 
+	:global(:root) {
+		--float-btn-size: clamp(40px, 9vw, 56px);
+		--float-btn-gap: clamp(8px, 2vw, 14px);
+		--float-btn-left: calc(min(3vw, 1em) + 4px);
+	}
+
+	.ctrl-btn {
+		bottom: 1rem;
+	}
+
 	.record-btn {
-		left: 3em;
+		bottom: calc(1rem + var(--float-btn-size) + var(--float-btn-gap));
+		left: calc(var(--float-btn-left) + var(--float-btn-size) + var(--float-btn-gap));
+		translate: 0 calc(2rem - var(--float-btn-size) - var(--float-btn-gap));
 	}
 
 	.locker-btn {
+		bottom: calc(1rem + (var(--float-btn-size) + var(--float-btn-gap)) * 2);
+		translate: 0 calc(4rem - (var(--float-btn-size) + var(--float-btn-gap)) * 2);
+
 		&::before {
 			content: var(--locker-icon, '🔓');
 		}
@@ -50,15 +65,15 @@
 		position: fixed;
 		z-index: 30;
 		/* bottom: .5rem; */
-		left: calc(min(3vw, 1em) + 4px);
+		left: var(--float-btn-left);
 		border: 1px outset #0006;
 		display: flex;
-		width: 2em;
-		height: 2em;
+		width: var(--float-btn-size);
+		height: var(--float-btn-size);
 		padding: 0;
 		place-items: center;
 		place-content: center;
-		font-size: .8rem;
+		font-size: clamp(1.1rem, 4vw, 1.5rem);
 		background-color: #f4f4f4;
 		cursor: pointer;
 		user-select: none;

--- a/src/component/Float_Btns.svelte
+++ b/src/component/Float_Btns.svelte
@@ -3,7 +3,7 @@
 	import { i18n } from '@lib/i18n.svelte.js';
 </script>
 
-<label class="btn-icon ctrl-btn hide-for-print" for="ctrl-checkbox" style="bottom:1rem">
+<label class="btn-icon ctrl-btn hide-for-print" for="ctrl-checkbox">
 	⚙️
 	<span class="sr-only-u">
 		toggle control panel
@@ -11,7 +11,7 @@
 </label>
 
 
-<button class="btn-icon record-btn hide-for-print" style="bottom:3rem"
+<button class="btn-icon record-btn hide-for-print"
 	onclick={recorder.add_current}
 	title={i18n.t('record.save')}
 >
@@ -21,7 +21,7 @@
 	</span>
 </button>
 
-<label class="btn-icon locker-btn hide-for-print" for="list-locker" style="bottom: 5rem">
+<label class="btn-icon locker-btn hide-for-print" for="list-locker">
 	<span class="sr-only-u">
 		Lock
 	</span>
@@ -35,21 +35,20 @@
 		--float-btn-size: clamp(40px, 9vw, 56px);
 		--float-btn-gap: clamp(8px, 2vw, 14px);
 		--float-btn-left: calc(min(3vw, 1em) + 4px);
+		--float-btn-bottom: calc(clamp(64px, 14vw, 88px) + env(safe-area-inset-bottom, 0px));
 	}
 
 	.ctrl-btn {
-		bottom: 1rem;
+		bottom: var(--float-btn-bottom);
 	}
 
 	.record-btn {
-		bottom: calc(1rem + var(--float-btn-size) + var(--float-btn-gap));
+		bottom: calc(var(--float-btn-bottom) + var(--float-btn-size) + var(--float-btn-gap));
 		left: calc(var(--float-btn-left) + var(--float-btn-size) + var(--float-btn-gap));
-		translate: 0 calc(2rem - var(--float-btn-size) - var(--float-btn-gap));
 	}
 
 	.locker-btn {
-		bottom: calc(1rem + (var(--float-btn-size) + var(--float-btn-gap)) * 2);
-		translate: 0 calc(4rem - (var(--float-btn-size) + var(--float-btn-gap)) * 2);
+		bottom: calc(var(--float-btn-bottom) + (var(--float-btn-size) + var(--float-btn-gap)) * 2);
 
 		&::before {
 			content: var(--locker-icon, '🔓');


### PR DESCRIPTION
## Summary

Closes #101.

Fixes Rplus/pokemongo-shiny#101 by making the three floating left-side controls easier to tap on touch devices.

The previous floating buttons were sized from a small `2em` box with `.8rem` icons, which made Lock, Save, and Settings buttons difficult to hit reliably on phones/tablets.

## What changed

This keeps the existing floating-button layout and behavior, but introduces shared responsive sizing variables for the controls:

- `--float-btn-size` scales the button touch target with the viewport using `clamp(40px, 9vw, 56px)`
- `--float-btn-gap` scales the vertical spacing between controls
- `--float-btn-left` keeps the left-side positioning centralized

The Save and Lock controls derive their spacing from the same responsive size/gap values, so the cluster grows proportionally without overlapping. The icon size also scales with the button size.

## Testing

- Ran `npm run build`
- Verified locally with the repo local live-test workflow
